### PR TITLE
bug: fix reset error

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 export function getObjVal(obj, key) {
-  return key ? obj[key] : obj
+  return key ? (obj ? obj[key] : obj) : obj
 }
 
 export function isPromise(val) {


### PR DESCRIPTION
- description
   修复调用reset方法时的错误
- detail
   reset内部会调用`getObjVal(newVal[0], this.valueKey)`，而`newVal[0]`为undeinfed，`obj[key]`获取失败